### PR TITLE
Fix splicer-stream call, Update to new ndjson module name

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var path = require('path')
 var execspawn = require('npm-execspawn')
 var xtend = require('xtend')
 var resolve = require('resolve')
-var ldjson = require('ldjson-stream')
+var ndjson = require('ndjson')
 var splicer = require('stream-splicer')
 var duplexer = require('duplexer2')
 var stream = require('stream')
@@ -11,7 +11,7 @@ var debug = require('debug-stream')('gasket')
 
 var compileModule = function(p, opts) {
   if (!p.exports) p.exports = require(resolve.sync(p.module, {basedir:opts.cwd}))
-  return p.json ? splicer(ldjson.parse(), p.exports(p), ldjson.serialize()) : p.exports(p)
+  return p.json ? splicer([ndjson.parse(), p.exports(p), ndjson.serialize()]) : p.exports(p)
 }
 
 var compileCommand = function(p, opts) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "debug-stream": "^2.0.2",
     "duplexer2": "0.0.2",
-    "ldjson-stream": "^1.1.0",
+    "ndjson": "^1.2.3",
     "npm-execspawn": "^1.0.6",
     "resolve": "^0.7.1",
     "stream-splicer": "^1.3.0",


### PR DESCRIPTION
I was running into an issue with the `json: true` option, because the splicer call wasn't correct. I took the opportunity to also update `ldjson-stream` to the new module name `ndjson`.
