### PR TITLE
Support new gasket.json format for types, added types fork, background, map, reduce, and updated README

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "pumpify": "^1.3.3",
     "resolve": "^0.7.1",
     "tabalot": "^0.6.0",
-    "xtend": "^3.0.0"
+    "xtend": "^3.0.0",
+    "parallel-multistream": "^1.0.1"
   },
   "gasket": {
     "test": [

--- a/readme.md
+++ b/readme.md
@@ -22,8 +22,14 @@ To setup a pipeline add a `gasket` section to your package.json
   },
   "gasket": {
     "example": [
-      "echo hello world",
-      "transform-uppercase"
+      {
+        "command": "echo hello world",
+        "type": "pipe"
+      },
+      {
+        "command": "transform-uppercase",
+        "type": "pipe"
+      }
     ]
   }
 }
@@ -36,17 +42,22 @@ $ gasket run example # will print HELLO WORLD
 ```
 
 `gasket` will spawn each command in the pipeline (it supports modules/commands installed via npm)
-and pipe them together.
+and pipe them together (if the type is set to "pipe").
 
-If you want to wait for the previous command to finish add `null` to the pipeline
+If you want to wait for the previous command to finish, set the type to "run" instead.
 
 ```json
 {
   "gasket": {
     "example": [
-      "echo hello world",
-      null,
-      "echo hello afterwards"
+      {
+        "command": "echo hello world",
+        "type": "run"
+      },
+      {
+        "command": "echo hello afterwards",
+        "type": "run"
+      }
     ]
   }
 }
@@ -66,8 +77,14 @@ In addition to commands it supports node modules that return streams
 ```json
 {
   "gasket": [
-    "echo hello world",
-    {"module":"./uppercase.js"}
+    {
+      "command": "echo hello world",
+      "type": "pipe"
+    }
+    {
+      "command": {"module":"./uppercase.js"},
+      "type": "pipe"
+    }
   ]
 }
 ```
@@ -96,8 +113,14 @@ If you don't have a package.json file you can add the tasks to a `gasket.json` f
 ```json
 {
   "example": [
-    "echo hello world",
-    "transform-uppercase"
+    {
+      "command": "echo hello world",
+      "type": "pipe"
+    },
+    {
+      "command": "transform-uppercase",
+      "type": "pipe"
+    }
   ]
 }
 ```
@@ -111,8 +134,14 @@ var gasket = require('gasket')
 
 var pipelines = gasket({
   example: [
-    "echo hello world",
-    "transform-uppercase"
+    {
+      "command": "echo hello world",
+      "type": "pipe"
+    },
+    {
+      "command": "transform-uppercase",
+      "type": "pipe"
+    }
   ]
 })
 


### PR DESCRIPTION
NOTE:  Planning to add support for nested commands in another PR

Following mafintosh's proposed plan here, which I really like:  https://gist.github.com/mafintosh/352f84dc924e0c404e99

- Changed gasket format (object with .command and .type) to support different types and nesting later on
- Treat commands as streams
- Added fork, backgrounds, map, and reduce in addition to pre-existing pipe/run commands
- Updated README to include other command-types and how to use them

Feedback appreciated!